### PR TITLE
Complete KPI/OKR create + check-in flows (OKR departments/missions, KR link, check-in form)

### DIFF
--- a/Controllers/KpiSetupController.cs
+++ b/Controllers/KpiSetupController.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore;
+using OmniBizAI.Data;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OmniBizAI.Services;
@@ -6,7 +8,7 @@ using OmniBizAI.ViewModels;
 namespace OmniBizAI.Controllers;
 
 [Authorize]
-public class KpiSetupController(KpiManagementService kpiService) : Controller
+public class KpiSetupController(KpiManagementService kpiService, ApplicationDbContext db, ITenantContext tenant) : Controller
 {
     public async Task<IActionResult> Index(string? search, string? status, string? periodId, string? ownerType)
     {
@@ -27,6 +29,20 @@ public class KpiSetupController(KpiManagementService kpiService) : Controller
         return View(vm);
     }
 
+
+
+    [HttpGet]
+    public async Task<IActionResult> KeyResults(Guid okrObjectiveId)
+    {
+        var items = await db.OkrKeyResults
+            .Where(kr => kr.TenantId == tenant.TenantId && !kr.IsDeleted && kr.OkrObjectiveId == okrObjectiveId)
+            .OrderBy(kr => kr.KeyResultName)
+            .Select(kr => new { value = kr.Id, text = kr.KeyResultName })
+            .ToListAsync();
+
+        return Json(items);
+    }
+
     [HttpPost]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Create(KpiCreateViewModel vm)
@@ -36,11 +52,26 @@ public class KpiSetupController(KpiManagementService kpiService) : Controller
             var form = await kpiService.GetCreateFormAsync();
             vm.Departments = form.Departments;
             vm.OkrObjectives = form.OkrObjectives;
+            vm.OkrKeyResults = form.OkrKeyResults;
             vm.Periods = form.Periods;
             return View(vm);
         }
-        var id = await kpiService.CreateAsync(vm);
-        TempData["Success"] = "Đã tạo KPI thành công.";
-        return RedirectToAction(nameof(Details), new { id });
+        try
+        {
+            var id = await kpiService.CreateAsync(vm);
+            TempData["Success"] = "Đã tạo KPI thành công.";
+            return RedirectToAction(nameof(Details), new { id });
+        }
+        catch (InvalidOperationException ex)
+        {
+            ModelState.AddModelError(nameof(vm.OkrKeyResultId), ex.Message);
+            var form = await kpiService.GetCreateFormAsync();
+            vm.Departments = form.Departments;
+            vm.OkrObjectives = form.OkrObjectives;
+            vm.OkrKeyResults = form.OkrKeyResults;
+            vm.Periods = form.Periods;
+            return View(vm);
+        }
+
     }
 }

--- a/Services/KpiOkrServices.cs
+++ b/Services/KpiOkrServices.cs
@@ -104,6 +104,34 @@ public class OkrService(ApplicationDbContext db, ITenantContext tenant)
             CreatedAt = DateTimeOffset.UtcNow
         };
 
+        if (vm.SelectedMissionIds.Any())
+        {
+            foreach (var missionId in vm.SelectedMissionIds.Distinct())
+            {
+                entity.MissionMappings.Add(new OkrMissionMapping
+                {
+                    TenantId = tid,
+                    MissionVisionId = missionId,
+                    CreatedByUserId = tenant.UserId,
+                    CreatedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+
+        if (vm.SelectedDepartmentIds.Any())
+        {
+            foreach (var departmentId in vm.SelectedDepartmentIds.Distinct())
+            {
+                entity.DepartmentAllocations.Add(new OkrDepartmentAllocation
+                {
+                    TenantId = tid,
+                    OrganizationUnitId = departmentId,
+                    CreatedByUserId = tenant.UserId,
+                    CreatedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+
         if (vm.KeyResults?.Any() == true)
         {
             foreach (var kr in vm.KeyResults)
@@ -266,6 +294,12 @@ public class KpiManagementService(ApplicationDbContext db, ITenantContext tenant
         var tid = tenant.TenantId;
         var count = await db.KpiDefinitions.CountAsync(k => k.TenantId == tid);
 
+        if (vm.OkrKeyResultId.HasValue && vm.OkrObjectiveId.HasValue)
+        {
+            var linked = await db.OkrKeyResults.AnyAsync(kr => kr.Id == vm.OkrKeyResultId && kr.OkrObjectiveId == vm.OkrObjectiveId && !kr.IsDeleted && kr.TenantId == tid);
+            if (!linked) throw new InvalidOperationException("Key Result không thuộc OKR đã chọn.");
+        }
+
         var entity = new KpiDefinition
         {
             TenantId = tid,
@@ -331,6 +365,10 @@ public class KpiManagementService(ApplicationDbContext db, ITenantContext tenant
             OkrObjectives = await db.OkrObjectives
                 .Where(o => o.TenantId == tid && o.IsActive && !o.IsDeleted && o.Status == OkrStatus.Active)
                 .Select(o => new SelectOption { Value = o.Id.ToString(), Text = o.ObjectiveName }).ToListAsync(),
+            OkrKeyResults = await db.OkrKeyResults
+                .Where(kr => kr.TenantId == tid && !kr.IsDeleted)
+                .OrderBy(kr => kr.KeyResultName)
+                .Select(kr => new SelectOption { Value = kr.Id.ToString(), Text = kr.KeyResultName }).ToListAsync(),
             Periods = await db.EvaluationPeriods
                 .Where(p => p.TenantId == tid && !p.IsDeleted && p.Status != EvaluationPeriodStatus.Closed)
                 .Select(p => new SelectOption { Value = p.Id.ToString(), Text = p.PeriodName }).ToListAsync()
@@ -378,6 +416,11 @@ public class KpiCheckInService(ApplicationDbContext db, ITenantContext tenant)
         return new KpiCheckInListViewModel
         {
             Items = items,
+            AvailableTargets = await db.KpiTargets
+                .Where(t => t.TenantId == tid && !t.IsDeleted && t.KpiDefinition != null && !t.KpiDefinition.IsDeleted && t.KpiDefinition.Status == KpiStatus.Active)
+                .OrderBy(t => t.KpiDefinition!.Code)
+                .Select(t => new SelectOption { Value = t.Id.ToString(), Text = $"{t.KpiDefinition!.Code} - {t.KpiDefinition.Name}" })
+                .ToListAsync(),
             TotalCount = total,
             Page = page,
             SearchTerm = search,

--- a/ViewModels/KpiOkrViewModels.cs
+++ b/ViewModels/KpiOkrViewModels.cs
@@ -69,6 +69,10 @@ public class OkrCreateViewModel
     public List<OkrKeyResultCreateItem>? KeyResults { get; set; }
 
     // Dropdowns
+    public List<Guid> SelectedDepartmentIds { get; set; } = new();
+    public List<Guid> SelectedMissionIds { get; set; } = new();
+
+    // Dropdowns
     public List<SelectOption> Departments { get; set; } = new();
     public List<SelectOption> Missions { get; set; } = new();
 }
@@ -195,6 +199,7 @@ public class KpiCreateViewModel
     // Dropdowns
     public List<SelectOption> Departments { get; set; } = new();
     public List<SelectOption> OkrObjectives { get; set; } = new();
+    public List<SelectOption> OkrKeyResults { get; set; } = new();
     public List<SelectOption> Periods { get; set; } = new();
 }
 
@@ -205,6 +210,8 @@ public class KpiCreateViewModel
 public class KpiCheckInListViewModel
 {
     public List<KpiCheckInListItem> Items { get; set; } = new();
+    public KpiCheckInSubmitViewModel SubmitForm { get; set; } = new();
+    public List<SelectOption> AvailableTargets { get; set; } = new();
     public int TotalCount { get; set; }
     public int Page { get; set; } = 1;
     public int PageSize { get; set; } = 20;

--- a/Views/KpiCheckIn/Index.cshtml
+++ b/Views/KpiCheckIn/Index.cshtml
@@ -27,6 +27,33 @@
     </div>
 }
 
+
+<div class="content-card mb-4">
+    <div class="card-header-custom"><h5><i class="bi bi-plus-circle"></i> Tạo Check-In mới</h5></div>
+    <div class="card-body-custom">
+        <form asp-action="Submit" method="post" class="row g-3">
+            <div class="col-md-5">
+                <label class="form-label">KPI Target</label>
+                <select name="KpiTargetId" class="form-select" required>
+                    <option value="">-- Chọn KPI --</option>
+                    @foreach (var t in Model.AvailableTargets) { <option value="@t.Value">@t.Text</option> }
+                </select>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Giá trị tiến độ</label>
+                <input name="ProgressValue" type="number" step="0.01" class="form-control" required />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Ghi chú</label>
+                <input name="Comment" class="form-control" />
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary"><i class="bi bi-send"></i> Gửi check-in</button>
+            </div>
+        </form>
+    </div>
+</div>
+
 <!-- Toolbar -->
 <div class="content-card mb-4">
     <div class="card-body-custom py-3">

--- a/Views/KpiSetup/Create.cshtml
+++ b/Views/KpiSetup/Create.cshtml
@@ -63,7 +63,12 @@
                 </div>
                 <div class="col-md-4">
                     <label asp-for="OkrObjectiveId" class="form-label">Gắn OKR</label>
-                    <select asp-for="OkrObjectiveId" class="form-select"><option value="">-- Không --</option>@foreach (var o in Model.OkrObjectives) { <option value="@o.Value">@o.Text</option> }</select>
+                    <select asp-for="OkrObjectiveId" id="okrObjectiveSelect" class="form-select"><option value="">-- Không --</option>@foreach (var o in Model.OkrObjectives) { <option value="@o.Value">@o.Text</option> }</select>
+                </div>
+                <div class="col-md-4">
+                    <label asp-for="OkrKeyResultId" class="form-label">Key Result</label>
+                    <select asp-for="OkrKeyResultId" id="okrKeyResultSelect" class="form-select"><option value="">-- Chọn KR --</option>@foreach (var kr in Model.OkrKeyResults) { <option value="@kr.Value">@kr.Text</option> }</select>
+                    <span asp-validation-for="OkrKeyResultId" class="text-danger"></span>
                 </div>
                 <div class="col-md-4">
                     <label asp-for="EvaluationPeriodId" class="form-label">Kỳ đánh giá</label>
@@ -95,3 +100,22 @@
         <a asp-action="Index" class="btn btn-outline-secondary">Hủy</a>
     </div>
 </form>
+
+@section Scripts {
+<script>
+document.getElementById('okrObjectiveSelect')?.addEventListener('change', async function() {
+    const objectiveId = this.value;
+    const krSelect = document.getElementById('okrKeyResultSelect');
+    krSelect.innerHTML = '<option value="">-- Chọn KR --</option>';
+    if (!objectiveId) return;
+    const res = await fetch(`@Url.Action("KeyResults", "KpiSetup")?okrObjectiveId=${objectiveId}`);
+    const data = await res.json();
+    for (const item of data) {
+        const opt = document.createElement('option');
+        opt.value = item.value;
+        opt.textContent = item.text;
+        krSelect.appendChild(opt);
+    }
+});
+</script>
+}

--- a/Views/Okr/Create.cshtml
+++ b/Views/Okr/Create.cshtml
@@ -29,6 +29,21 @@
                     <input asp-for="Cycle" class="form-control" placeholder="VD: Q2-2026" />
                 </div>
             </div>
+            <div class="row g-3 mt-1">
+                <div class="col-md-6">
+                    <label asp-for="SelectedDepartmentIds" class="form-label">Phòng ban áp dụng</label>
+                    <select asp-for="SelectedDepartmentIds" class="form-select" multiple size="4">
+                        @foreach (var d in Model.Departments) { <option value="@d.Value">@d.Text</option> }
+                    </select>
+                </div>
+                <div class="col-md-6">
+                    <label asp-for="SelectedMissionIds" class="form-label">Liên kết sứ mệnh/tầm nhìn</label>
+                    <select asp-for="SelectedMissionIds" class="form-select" multiple size="4">
+                        @foreach (var m in Model.Missions) { <option value="@m.Value">@m.Text</option> }
+                    </select>
+                </div>
+            </div>
+
         </div>
     </div>
 


### PR DESCRIPTION
### Motivation
- Enable end-to-end KPI/OKR workflows so users can create OKRs linked to departments and mission/vision, create KPIs linked to OKR Key Results, and submit KPI check-ins from the UI. 
- Prevent invalid KPI creation by validating that a selected Key Result actually belongs to the chosen OKR. 
- Provide a simple in-page check-in submission to record user progress against active KPI targets.

### Description
- Added multi-select fields to the OKR create flow and persist mappings in `OkrService.CreateAsync`, and extended the `OkrCreateViewModel` with `SelectedDepartmentIds` and `SelectedMissionIds` (files: `Views/Okr/Create.cshtml`, `ViewModels/KpiOkrViewModels.cs`, `Services/KpiOkrServices.cs`).
- Added an endpoint `KeyResults` in `KpiSetupController` to return KR options by objective and wired dynamic KR loading in the KPI create view via JS, plus updated `KpiCreateViewModel` to include `OkrKeyResults` (files: `Controllers/KpiSetupController.cs`, `Views/KpiSetup/Create.cshtml`, `ViewModels/KpiOkrViewModels.cs`).
- Implemented backend validation in `KpiManagementService.CreateAsync` to ensure `OkrKeyResultId` belongs to `OkrObjectiveId` and surface a clear `InvalidOperationException` to the UI when mismatched (file: `Services/KpiOkrServices.cs`).
- Added a check-in submission form to the KPI Check-In index and populated `AvailableTargets` in the `KpiCheckInService.GetListAsync` projection so users can submit check-ins against active KPI targets (files: `Views/KpiCheckIn/Index.cshtml`, `Services/KpiOkrServices.cs`, `ViewModels/KpiOkrViewModels.cs`).
- Improved error flow in `KpiSetupController.Create` to display business validation errors and re-populate dropdowns when creation fails (file: `Controllers/KpiSetupController.cs`).

### Testing
- Attempted an automated project build with `dotnet build`, but the environment lacks the .NET SDK and the command failed with `dotnet: command not found`. No further automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08893f1ab4833394218ee735b3a2b0)