### PR TITLE
Integrate OKR Key Results into KPI creation, add KR lookup endpoint, extend OKR/KPI UIs

### DIFF
--- a/Controllers/KpiSetupController.cs
+++ b/Controllers/KpiSetupController.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore;
+using OmniBizAI.Data;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OmniBizAI.Services;
@@ -6,7 +8,7 @@ using OmniBizAI.ViewModels;
 namespace OmniBizAI.Controllers;
 
 [Authorize]
-public class KpiSetupController(KpiManagementService kpiService) : Controller
+public class KpiSetupController(KpiManagementService kpiService, ApplicationDbContext db, ITenantContext tenant) : Controller
 {
     public async Task<IActionResult> Index(string? search, string? status, string? periodId, string? ownerType)
     {
@@ -27,6 +29,20 @@ public class KpiSetupController(KpiManagementService kpiService) : Controller
         return View(vm);
     }
 
+
+
+    [HttpGet]
+    public async Task<IActionResult> KeyResults(Guid okrObjectiveId)
+    {
+        var items = await db.OkrKeyResults
+            .Where(kr => kr.TenantId == tenant.TenantId && !kr.IsDeleted && kr.OkrObjectiveId == okrObjectiveId)
+            .OrderBy(kr => kr.KeyResultName)
+            .Select(kr => new { value = kr.Id, text = kr.KeyResultName })
+            .ToListAsync();
+
+        return Json(items);
+    }
+
     [HttpPost]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Create(KpiCreateViewModel vm)
@@ -36,11 +52,26 @@ public class KpiSetupController(KpiManagementService kpiService) : Controller
             var form = await kpiService.GetCreateFormAsync();
             vm.Departments = form.Departments;
             vm.OkrObjectives = form.OkrObjectives;
+            vm.OkrKeyResults = form.OkrKeyResults;
             vm.Periods = form.Periods;
             return View(vm);
         }
-        var id = await kpiService.CreateAsync(vm);
-        TempData["Success"] = "Đã tạo KPI thành công.";
-        return RedirectToAction(nameof(Details), new { id });
+        try
+        {
+            var id = await kpiService.CreateAsync(vm);
+            TempData["Success"] = "Đã tạo KPI thành công.";
+            return RedirectToAction(nameof(Details), new { id });
+        }
+        catch (InvalidOperationException ex)
+        {
+            ModelState.AddModelError(nameof(vm.OkrKeyResultId), ex.Message);
+            var form = await kpiService.GetCreateFormAsync();
+            vm.Departments = form.Departments;
+            vm.OkrObjectives = form.OkrObjectives;
+            vm.OkrKeyResults = form.OkrKeyResults;
+            vm.Periods = form.Periods;
+            return View(vm);
+        }
+
     }
 }

--- a/Services/KpiOkrServices.cs
+++ b/Services/KpiOkrServices.cs
@@ -104,6 +104,50 @@ public class OkrService(ApplicationDbContext db, ITenantContext tenant)
             CreatedAt = DateTimeOffset.UtcNow
         };
 
+        if (vm.SelectedMissionIds.Any())
+        {
+            foreach (var missionId in vm.SelectedMissionIds.Distinct())
+            {
+                entity.MissionMappings.Add(new OkrMissionMapping
+                {
+                    TenantId = tid,
+                    MissionVisionId = missionId,
+                    CreatedByUserId = tenant.UserId,
+                    CreatedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+
+        if (vm.SelectedDepartmentIds.Any())
+        {
+            foreach (var departmentId in vm.SelectedDepartmentIds.Distinct())
+            {
+                entity.DepartmentAllocations.Add(new OkrDepartmentAllocation
+                {
+                    TenantId = tid,
+                    OrganizationUnitId = departmentId,
+                    CreatedByUserId = tenant.UserId,
+                    CreatedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+
+
+
+        if (vm.SelectedEmployeeIds.Any())
+        {
+            foreach (var userId in vm.SelectedEmployeeIds.Distinct())
+            {
+                entity.EmployeeAllocations.Add(new OkrEmployeeAllocation
+                {
+                    TenantId = tid,
+                    UserId = userId,
+                    CreatedByUserId = tenant.UserId,
+                    CreatedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+
         if (vm.KeyResults?.Any() == true)
         {
             foreach (var kr in vm.KeyResults)
@@ -146,6 +190,11 @@ public class OkrService(ApplicationDbContext db, ITenantContext tenant)
             Missions = await db.MissionVisions
                 .Where(m => m.TenantId == tid && m.IsActive && !m.IsDeleted)
                 .Select(m => new SelectOption { Value = m.Id.ToString(), Text = m.Content ?? "" })
+                .ToListAsync(),
+            Employees = await db.AppUsers
+                .Where(u => u.TenantId == tid && !u.IsDeleted && u.Status == UserStatus.Active)
+                .OrderBy(u => u.FullName)
+                .Select(u => new SelectOption { Value = u.Id.ToString(), Text = u.FullName })
                 .ToListAsync()
         };
     }
@@ -266,6 +315,15 @@ public class KpiManagementService(ApplicationDbContext db, ITenantContext tenant
         var tid = tenant.TenantId;
         var count = await db.KpiDefinitions.CountAsync(k => k.TenantId == tid);
 
+        if (vm.OkrKeyResultId.HasValue && !vm.OkrObjectiveId.HasValue)
+            throw new InvalidOperationException("Vui lòng chọn OKR Objective trước khi chọn Key Result.");
+
+        if (vm.OkrKeyResultId.HasValue && vm.OkrObjectiveId.HasValue)
+        {
+            var linked = await db.OkrKeyResults.AnyAsync(kr => kr.Id == vm.OkrKeyResultId && kr.OkrObjectiveId == vm.OkrObjectiveId && !kr.IsDeleted && kr.TenantId == tid);
+            if (!linked) throw new InvalidOperationException("Key Result không thuộc OKR đã chọn.");
+        }
+
         var entity = new KpiDefinition
         {
             TenantId = tid,
@@ -331,6 +389,10 @@ public class KpiManagementService(ApplicationDbContext db, ITenantContext tenant
             OkrObjectives = await db.OkrObjectives
                 .Where(o => o.TenantId == tid && o.IsActive && !o.IsDeleted && o.Status == OkrStatus.Active)
                 .Select(o => new SelectOption { Value = o.Id.ToString(), Text = o.ObjectiveName }).ToListAsync(),
+            OkrKeyResults = await db.OkrKeyResults
+                .Where(kr => kr.TenantId == tid && !kr.IsDeleted)
+                .OrderBy(kr => kr.KeyResultName)
+                .Select(kr => new SelectOption { Value = kr.Id.ToString(), Text = kr.KeyResultName }).ToListAsync(),
             Periods = await db.EvaluationPeriods
                 .Where(p => p.TenantId == tid && !p.IsDeleted && p.Status != EvaluationPeriodStatus.Closed)
                 .Select(p => new SelectOption { Value = p.Id.ToString(), Text = p.PeriodName }).ToListAsync()
@@ -378,6 +440,11 @@ public class KpiCheckInService(ApplicationDbContext db, ITenantContext tenant)
         return new KpiCheckInListViewModel
         {
             Items = items,
+            AvailableTargets = await db.KpiTargets
+                .Where(t => t.TenantId == tid && !t.IsDeleted && t.KpiDefinition != null && !t.KpiDefinition.IsDeleted && t.KpiDefinition.Status == KpiStatus.Active)
+                .OrderBy(t => t.KpiDefinition!.Code)
+                .Select(t => new SelectOption { Value = t.Id.ToString(), Text = $"{t.KpiDefinition!.Code} - {t.KpiDefinition.Name}" })
+                .ToListAsync(),
             TotalCount = total,
             Page = page,
             SearchTerm = search,

--- a/ViewModels/KpiOkrViewModels.cs
+++ b/ViewModels/KpiOkrViewModels.cs
@@ -69,8 +69,14 @@ public class OkrCreateViewModel
     public List<OkrKeyResultCreateItem>? KeyResults { get; set; }
 
     // Dropdowns
+    public List<Guid> SelectedDepartmentIds { get; set; } = new();
+    public List<Guid> SelectedMissionIds { get; set; } = new();
+    public List<Guid> SelectedEmployeeIds { get; set; } = new();
+
+    // Dropdowns
     public List<SelectOption> Departments { get; set; } = new();
     public List<SelectOption> Missions { get; set; } = new();
+    public List<SelectOption> Employees { get; set; } = new();
 }
 
 public class OkrKeyResultCreateItem
@@ -195,6 +201,7 @@ public class KpiCreateViewModel
     // Dropdowns
     public List<SelectOption> Departments { get; set; } = new();
     public List<SelectOption> OkrObjectives { get; set; } = new();
+    public List<SelectOption> OkrKeyResults { get; set; } = new();
     public List<SelectOption> Periods { get; set; } = new();
 }
 
@@ -205,6 +212,8 @@ public class KpiCreateViewModel
 public class KpiCheckInListViewModel
 {
     public List<KpiCheckInListItem> Items { get; set; } = new();
+    public KpiCheckInSubmitViewModel SubmitForm { get; set; } = new();
+    public List<SelectOption> AvailableTargets { get; set; } = new();
     public int TotalCount { get; set; }
     public int Page { get; set; } = 1;
     public int PageSize { get; set; } = 20;

--- a/Views/KpiCheckIn/Index.cshtml
+++ b/Views/KpiCheckIn/Index.cshtml
@@ -27,6 +27,34 @@
     </div>
 }
 
+
+<div class="content-card mb-4">
+    <div class="card-header-custom"><h5><i class="bi bi-plus-circle"></i> Tạo Check-In mới</h5></div>
+    <div class="card-body-custom">
+        <div class="small text-muted mb-3">Chọn KPI cần cập nhật, nhập giá trị mới nhất và thêm ghi chú ngắn (nếu có).</div>
+        <form asp-action="Submit" method="post" class="row g-3">
+            <div class="col-md-5">
+                <label class="form-label">KPI Target</label>
+                <select name="KpiTargetId" class="form-select" required>
+                    <option value="">-- Chọn KPI --</option>
+                    @foreach (var t in Model.AvailableTargets) { <option value="@t.Value">@t.Text</option> }
+                </select>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Giá trị tiến độ</label>
+                <input name="ProgressValue" type="number" step="0.01" class="form-control" required />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Ghi chú</label>
+                <input name="Comment" class="form-control" />
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary"><i class="bi bi-send"></i> Gửi check-in</button>
+            </div>
+        </form>
+    </div>
+</div>
+
 <!-- Toolbar -->
 <div class="content-card mb-4">
     <div class="card-body-custom py-3">

--- a/Views/KpiSetup/Create.cshtml
+++ b/Views/KpiSetup/Create.cshtml
@@ -59,11 +59,19 @@
                 </div>
                 <div class="col-md-4">
                     <label asp-for="OrganizationUnitId" class="form-label">Phòng ban</label>
+                    <small class="text-muted d-block mb-1">Dùng khi KPI áp dụng cho đơn vị cụ thể</small>
                     <select asp-for="OrganizationUnitId" class="form-select"><option value="">-- Chọn --</option>@foreach (var d in Model.Departments) { <option value="@d.Value">@d.Text</option> }</select>
                 </div>
                 <div class="col-md-4">
                     <label asp-for="OkrObjectiveId" class="form-label">Gắn OKR</label>
-                    <select asp-for="OkrObjectiveId" class="form-select"><option value="">-- Không --</option>@foreach (var o in Model.OkrObjectives) { <option value="@o.Value">@o.Text</option> }</select>
+                    <small class="text-muted d-block mb-1">Bước 1: chọn Objective</small>
+                    <select asp-for="OkrObjectiveId" id="okrObjectiveSelect" class="form-select"><option value="">-- Không --</option>@foreach (var o in Model.OkrObjectives) { <option value="@o.Value">@o.Text</option> }</select>
+                </div>
+                <div class="col-md-4">
+                    <label asp-for="OkrKeyResultId" class="form-label">Key Result</label>
+                    <small id="krHint" class="text-muted d-block mb-1">Bước 2: chọn Key Result thuộc Objective</small>
+                    <select asp-for="OkrKeyResultId" id="okrKeyResultSelect" class="form-select" disabled><option value="">-- Chọn OKR trước --</option>@foreach (var kr in Model.OkrKeyResults) { <option value="@kr.Value">@kr.Text</option> }</select>
+                    <span asp-validation-for="OkrKeyResultId" class="text-danger"></span>
                 </div>
                 <div class="col-md-4">
                     <label asp-for="EvaluationPeriodId" class="form-label">Kỳ đánh giá</label>
@@ -77,6 +85,9 @@
     <div class="card border-0 shadow-sm mb-4">
         <div class="card-header bg-transparent"><h5 class="mb-0"><i class="bi bi-bullseye me-2"></i>Chỉ tiêu & Lịch check-in</h5></div>
         <div class="card-body">
+            <div class="alert alert-light border mb-3 small">
+                <strong>Hướng dẫn nhanh:</strong> Điền thông tin cơ bản → chọn phạm vi giao KPI → liên kết OKR/KR (nếu có) → thiết lập chỉ tiêu.
+            </div>
             <div class="row g-3">
                 <div class="col-md-3"><label asp-for="TargetValue" class="form-label">Giá trị mục tiêu</label><input asp-for="TargetValue" type="number" step="0.01" class="form-control" /></div>
                 <div class="col-md-3"><label asp-for="PassThreshold" class="form-label">Ngưỡng đạt</label><input asp-for="PassThreshold" type="number" step="0.01" class="form-control" /></div>
@@ -95,3 +106,35 @@
         <a asp-action="Index" class="btn btn-outline-secondary">Hủy</a>
     </div>
 </form>
+
+@section Scripts {
+<script>
+document.getElementById('okrObjectiveSelect')?.addEventListener('change', async function() {
+    const objectiveId = this.value;
+    const krSelect = document.getElementById('okrKeyResultSelect');
+    const krHint = document.getElementById('krHint');
+    krSelect.innerHTML = '<option value="">-- Chọn KR --</option>';
+    krSelect.disabled = true;
+    if (!objectiveId) {
+        krSelect.innerHTML = '<option value="">-- Chọn OKR trước --</option>';
+        krHint.textContent = 'Bước 2: chọn Key Result thuộc Objective';
+        return;
+    }
+    const res = await fetch(`@Url.Action("KeyResults", "KpiSetup")?okrObjectiveId=${objectiveId}`);
+    const data = await res.json();
+    if (!data.length) {
+        krSelect.innerHTML = "<option value="">-- Objective chưa có KR --</option>";
+        krHint.textContent = "Objective này chưa có Key Result.";
+        return;
+    }
+    krSelect.disabled = false;
+    krHint.textContent = `Có ${data.length} KR khả dụng`;
+    for (const item of data) {
+        const opt = document.createElement('option');
+        opt.value = item.value;
+        opt.textContent = item.text;
+        krSelect.appendChild(opt);
+    }
+});
+</script>
+}

--- a/Views/KpiSetup/Details.cshtml
+++ b/Views/KpiSetup/Details.cshtml
@@ -26,6 +26,7 @@
                     <div class="col-6 col-md-3"><strong class="small text-muted d-block">Tính chất</strong>@Model.PropertyType</div>
                     @if (Model.Department != null) { <div class="col-6 col-md-3"><strong class="small text-muted d-block">Phòng ban</strong>@Model.Department</div> }
                     @if (Model.OkrName != null) { <div class="col-6 col-md-3"><strong class="small text-muted d-block">OKR</strong>@Model.OkrName</div> }
+                    @if (Model.KeyResultName != null) { <div class="col-6 col-md-3"><strong class="small text-muted d-block">Key Result</strong>@Model.KeyResultName</div> }
                     @if (Model.PeriodName != null) { <div class="col-6 col-md-3"><strong class="small text-muted d-block">Kỳ đánh giá</strong>@Model.PeriodName</div> }
                     @if (Model.AssignerName != null) { <div class="col-6 col-md-3"><strong class="small text-muted d-block">Người giao</strong>@Model.AssignerName</div> }
                 </div>

--- a/Views/Okr/Create.cshtml
+++ b/Views/Okr/Create.cshtml
@@ -10,6 +10,9 @@
     <div class="card border-0 shadow-sm mb-4">
         <div class="card-header bg-transparent"><h5 class="mb-0">Thông tin mục tiêu</h5></div>
         <div class="card-body">
+            <div class="alert alert-light border mb-3 small">
+                <strong>Thiết lập theo bước:</strong> 1) Mục tiêu 2) Phạm vi áp dụng (phòng ban/mission/nhân sự) 3) Key Results đo lường.
+            </div>
             <div class="row g-3">
                 <div class="col-md-8">
                     <label asp-for="ObjectiveName" class="form-label">Tên mục tiêu <span class="text-danger">*</span></label>
@@ -29,6 +32,30 @@
                     <input asp-for="Cycle" class="form-control" placeholder="VD: Q2-2026" />
                 </div>
             </div>
+            <div class="row g-3 mt-1">
+                <div class="col-md-4">
+                    <label asp-for="SelectedDepartmentIds" class="form-label">Phòng ban áp dụng</label>
+                    <small class="text-muted d-block mb-1">Có thể chọn nhiều phòng ban bằng Ctrl/⌘ + click</small>
+                    <select asp-for="SelectedDepartmentIds" class="form-select" multiple size="4">
+                        @foreach (var d in Model.Departments) { <option value="@d.Value">@d.Text</option> }
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <label asp-for="SelectedMissionIds" class="form-label">Liên kết sứ mệnh/tầm nhìn</label>
+                    <small class="text-muted d-block mb-1">Gắn với định hướng chiến lược liên quan</small>
+                    <select asp-for="SelectedMissionIds" class="form-select" multiple size="4">
+                        @foreach (var m in Model.Missions) { <option value="@m.Value">@m.Text</option> }
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <label asp-for="SelectedEmployeeIds" class="form-label">Nhân sự phụ trách</label>
+                    <small class="text-muted d-block mb-1">Chọn các cá nhân chịu trách nhiệm chính</small>
+                    <select asp-for="SelectedEmployeeIds" class="form-select" multiple size="4">
+                        @foreach (var e in Model.Employees) { <option value="@e.Value">@e.Text</option> }
+                    </select>
+                </div>
+            </div>
+
         </div>
     </div>
 


### PR DESCRIPTION
### Motivation
- Allow KPIs to be linked to OKR Key Results and ensure the selected KR belongs to the chosen Objective to prevent inconsistent links.
- Provide a dynamic endpoint to load Key Results for an Objective so the UI can fetch KRs on demand.
- Extend OKR creation to assign departments/missions/employees and surface employees in the create form.
- Add a lightweight KPI Check-In quick-create UI using available KPI targets.

### Description
- Controller: `KpiSetupController` now injects `ApplicationDbContext` and `ITenantContext` and exposes a `KeyResults(Guid okrObjectiveId)` GET action that returns KR options as JSON.
- Service: `KpiManagementService.CreateAsync` validates that if `OkrKeyResultId` is set then `OkrObjectiveId` must be set and that the KR belongs to that objective, throwing `InvalidOperationException` on violations; `GetCreateFormAsync` now includes `OkrKeyResults` in the form payload.
- Service: `OkrService.CreateAsync` now persists selected department/mission/employee allocations (`OkrDepartmentAllocation`, `OkrMissionMapping`, `OkrEmployeeAllocation`) and `GetCreateFormAsync` exposes `Employees` for selection.
- ViewModels: added fields for selected department/mission/employee IDs in `OkrCreateViewModel`, added `OkrKeyResults` to `KpiCreateViewModel`, and enriched `KpiCheckInListViewModel` with `AvailableTargets` and `SubmitForm`.
- Views: updated `Views/KpiSetup/Create.cshtml` to add a dependent Key Result dropdown with client-side JS that calls the new `KeyResults` action; `Details.cshtml` shows the Key Result name; `Views/Okr/Create.cshtml` supports multi-select departments/missions/employees; `Views/KpiCheckIn/Index.cshtml` adds a quick check-in form using `AvailableTargets`.
- UI/UX: added small guidance alerts and hints, and server-side ModelState handling in `KpiSetupController.Create` to repopulate dropdown lists (including `OkrKeyResults`) when validation fails.

### Testing
- Built the solution with `dotnet build` and ensured the project compiles successfully.
- Ran the existing unit/integration test suite with `dotnet test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08893f1ab4833394218ee735b3a2b0)