### PR TITLE
Bổ sung luồng Quản lý Tài nguyên cho Vận hành

### DIFF
--- a/Controllers/ResourceManagementController.cs
+++ b/Controllers/ResourceManagementController.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OmniBizAI.Data;
+using OmniBizAI.Models.Entities.Enums;
+using OmniBizAI.Services;
+using OmniBizAI.ViewModels;
+
+namespace OmniBizAI.Controllers;
+
+[Authorize]
+public class ResourceManagementController : Controller
+{
+    private readonly ApplicationDbContext _db;
+    private readonly ITenantContext _tenant;
+
+    public ResourceManagementController(ApplicationDbContext db, ITenantContext tenant)
+    {
+        _db = db;
+        _tenant = tenant;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var tid = _tenant.TenantId;
+        var today = DateOnly.FromDateTime(DateTime.Today);
+
+        var vm = new ResourceManagementDashboardViewModel
+        {
+            Human = new HumanResourceOverviewViewModel
+            {
+                TotalEmployees = await _db.EmployeeProfiles.CountAsync(x => x.TenantId == tid && !x.IsDeleted),
+                OnLeaveToday = await _db.LeaveRequests.CountAsync(x => x.TenantId == tid && !x.IsDeleted && x.Status == LeaveStatus.Approved && x.StartDate <= today && x.EndDate >= today),
+                PendingLeaves = await _db.LeaveRequests.CountAsync(x => x.TenantId == tid && !x.IsDeleted && x.Status == LeaveStatus.Submitted),
+                AvgPerformanceScore = await _db.EvaluationResults.Where(x => x.TenantId == tid && !x.IsDeleted).Select(x => (decimal?)x.FinalScore).AverageAsync() ?? 0
+            },
+            Equipment = new EquipmentResourceOverviewViewModel
+            {
+                TotalMaintenanceRequests = await _db.OperationRequests.CountAsync(x => x.TenantId == tid && !x.IsDeleted && x.Type == "Maintenance"),
+                ActiveMaintenanceRequests = await _db.OperationRequests.CountAsync(x => x.TenantId == tid && !x.IsDeleted && x.Type == "Maintenance" && (x.Status == OperationStatus.Submitted || x.Status == OperationStatus.InProgress)),
+                CompletedMaintenanceRequests = await _db.OperationRequests.CountAsync(x => x.TenantId == tid && !x.IsDeleted && x.Type == "Maintenance" && x.Status == OperationStatus.Completed),
+                OverdueMaintenanceRequests = await _db.OperationRequests.CountAsync(x => x.TenantId == tid && !x.IsDeleted && x.Type == "Maintenance" && x.DueDate.HasValue && x.DueDate < today && x.Status != OperationStatus.Completed)
+            },
+            Inventory = new InventoryResourceOverviewViewModel
+            {
+                TotalProducts = await _db.ProductServices.CountAsync(x => x.TenantId == tid && !x.IsDeleted),
+                ActiveStockAlerts = await _db.StockAlerts.CountAsync(x => x.TenantId == tid && !x.IsDeleted && x.IsActive),
+                GoodsReceiptCount = await _db.GoodsReceipts.CountAsync(x => x.TenantId == tid && !x.IsDeleted),
+                GoodsIssueCount = await _db.GoodsIssues.CountAsync(x => x.TenantId == tid && !x.IsDeleted)
+            },
+            Infrastructure = new InfrastructureResourceOverviewViewModel
+            {
+                TotalDepartments = await _db.OrganizationUnits.CountAsync(x => x.TenantId == tid && !x.IsDeleted),
+                TotalPositions = await _db.Positions.CountAsync(x => x.TenantId == tid && !x.IsDeleted),
+                TotalWorkCalendars = await _db.WorkCalendars.CountAsync(x => x.TenantId == tid && !x.IsDeleted),
+                TotalCustomerSites = await _db.CustomerSites.CountAsync(x => x.TenantId == tid && !x.IsDeleted)
+            }
+        };
+
+        return View(vm);
+    }
+}

--- a/ViewModels/ViewModels.cs
+++ b/ViewModels/ViewModels.cs
@@ -3081,3 +3081,43 @@ public class ChangePasswordViewModel
     public string ConfirmPassword { get; set; } = "";
 }
 
+
+public class ResourceManagementDashboardViewModel
+{
+    public HumanResourceOverviewViewModel Human { get; set; } = new();
+    public EquipmentResourceOverviewViewModel Equipment { get; set; } = new();
+    public InventoryResourceOverviewViewModel Inventory { get; set; } = new();
+    public InfrastructureResourceOverviewViewModel Infrastructure { get; set; } = new();
+}
+
+public class HumanResourceOverviewViewModel
+{
+    public int TotalEmployees { get; set; }
+    public int OnLeaveToday { get; set; }
+    public int PendingLeaves { get; set; }
+    public decimal AvgPerformanceScore { get; set; }
+}
+
+public class EquipmentResourceOverviewViewModel
+{
+    public int TotalMaintenanceRequests { get; set; }
+    public int ActiveMaintenanceRequests { get; set; }
+    public int CompletedMaintenanceRequests { get; set; }
+    public int OverdueMaintenanceRequests { get; set; }
+}
+
+public class InventoryResourceOverviewViewModel
+{
+    public int TotalProducts { get; set; }
+    public int ActiveStockAlerts { get; set; }
+    public int GoodsReceiptCount { get; set; }
+    public int GoodsIssueCount { get; set; }
+}
+
+public class InfrastructureResourceOverviewViewModel
+{
+    public int TotalDepartments { get; set; }
+    public int TotalPositions { get; set; }
+    public int TotalWorkCalendars { get; set; }
+    public int TotalCustomerSites { get; set; }
+}

--- a/Views/ResourceManagement/Index.cshtml
+++ b/Views/ResourceManagement/Index.cshtml
@@ -1,0 +1,66 @@
+@model OmniBizAI.ViewModels.ResourceManagementDashboardViewModel
+@{
+    ViewData["Title"] = "Quản lý tài nguyên";
+    ViewData["Breadcrumb"] = "<span>Vận hành</span> <i class='fa-solid fa-chevron-right mx-2' style='font-size:.6rem;color:var(--text-muted)'></i> <span>Quản lý tài nguyên</span>";
+}
+
+<div class="content-card mb-3">
+    <div class="card-body-custom">
+        <h5 class="mb-1"><i class="fa-solid fa-industry me-2" style="color:var(--apple-blue)"></i>Quản lý tài nguyên vận hành</h5>
+        <div style="color:var(--text-muted)">Theo dõi 4 nhóm tài nguyên cốt lõi: Nhân lực, Thiết bị/Máy móc, Vật tư/Kho, Cơ sở hạ tầng.</div>
+    </div>
+</div>
+
+<div class="row g-3">
+    <div class="col-lg-6">
+        <div class="content-card h-100"><div class="card-body-custom">
+            <h6>👥 Nhân lực</h6>
+            <div class="small text-muted mb-2">Ca làm việc, năng lực, chứng chỉ, hiệu suất</div>
+            <ul class="mb-0">
+                <li>Tổng nhân sự: <b>@Model.Human.TotalEmployees</b></li>
+                <li>Đang nghỉ hôm nay: <b>@Model.Human.OnLeaveToday</b></li>
+                <li>Đơn nghỉ chờ duyệt: <b>@Model.Human.PendingLeaves</b></li>
+                <li>Điểm hiệu suất TB: <b>@Model.Human.AvgPerformanceScore.ToString("0.0")</b></li>
+            </ul>
+        </div></div>
+    </div>
+
+    <div class="col-lg-6">
+        <div class="content-card h-100"><div class="card-body-custom">
+            <h6>🛠️ Thiết bị / Máy móc</h6>
+            <div class="small text-muted mb-2">Trạng thái, lịch bảo trì, tuổi thọ</div>
+            <ul class="mb-0">
+                <li>Yêu cầu bảo trì: <b>@Model.Equipment.TotalMaintenanceRequests</b></li>
+                <li>Đang xử lý: <b>@Model.Equipment.ActiveMaintenanceRequests</b></li>
+                <li>Hoàn thành: <b>@Model.Equipment.CompletedMaintenanceRequests</b></li>
+                <li>Quá hạn: <b>@Model.Equipment.OverdueMaintenanceRequests</b></li>
+            </ul>
+        </div></div>
+    </div>
+
+    <div class="col-lg-6">
+        <div class="content-card h-100"><div class="card-body-custom">
+            <h6>📦 Vật tư / Kho</h6>
+            <div class="small text-muted mb-2">Tồn kho, nhập xuất, cảnh báo tồn kho thấp</div>
+            <ul class="mb-0">
+                <li>Sản phẩm quản lý: <b>@Model.Inventory.TotalProducts</b></li>
+                <li>Cảnh báo tồn kho: <b>@Model.Inventory.ActiveStockAlerts</b></li>
+                <li>Phiếu nhập: <b>@Model.Inventory.GoodsReceiptCount</b></li>
+                <li>Phiếu xuất: <b>@Model.Inventory.GoodsIssueCount</b></li>
+            </ul>
+        </div></div>
+    </div>
+
+    <div class="col-lg-6">
+        <div class="content-card h-100"><div class="card-body-custom">
+            <h6>🏢 Cơ sở hạ tầng</h6>
+            <div class="small text-muted mb-2">Mặt bằng, phòng ban, vị trí làm việc</div>
+            <ul class="mb-0">
+                <li>Phòng ban: <b>@Model.Infrastructure.TotalDepartments</b></li>
+                <li>Vị trí làm việc/chức danh: <b>@Model.Infrastructure.TotalPositions</b></li>
+                <li>Lịch làm việc: <b>@Model.Infrastructure.TotalWorkCalendars</b></li>
+                <li>Điểm cơ sở (site): <b>@Model.Infrastructure.TotalCustomerSites</b></li>
+            </ul>
+        </div></div>
+    </div>
+</div>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -57,6 +57,12 @@
                     <span class="nav-badge" id="pendingBadge" style="display:none"></span>
                 </a>
 
+                <a class="nav-item @(ViewContext.RouteData.Values["controller"]?.ToString() == "ResourceManagement" ? "active" : "")"
+                   asp-controller="ResourceManagement" asp-action="Index">
+                    <i class="fa-solid fa-industry"></i>
+                    <span>Quản lý tài nguyên</span>
+                </a>
+
                 @if (User.IsInRole("STAFF") || User.IsInRole("DEPARTMENT_MANAGER") || User.IsInRole("EXECUTIVE") || User.IsInRole("TENANT_ADMIN") || User.IsInRole("SYSTEM_ADMIN"))
                 {
                     <a class="nav-item @(ViewContext.RouteData.Values["controller"]?.ToString() == "Workflow" ? "active" : "")"


### PR DESCRIPTION
### Motivation
- Thêm dashboard tổng quan để hoàn thiện mục "Quản Lý Tài Nguyên" trong luồng vận hành, gom dữ liệu theo 4 nhóm: Nhân lực, Thiết bị/Máy móc, Vật tư/Kho và Cơ sở hạ tầng.
- Mục tiêu là tái sử dụng dữ liệu hiện có trong hệ thống để nhanh chóng hiển thị chỉ số vận hành tài nguyên theo tenant.

### Description
- Thêm controller `ResourceManagementController` với action `Index` để tổng hợp các KPI theo tenant từ các bảng hiện có như `EmployeeProfiles`, `LeaveRequests`, `OperationRequests`, `ProductServices`, `StockAlerts`, `GoodsReceipts`, `GoodsIssues`, `OrganizationUnits`, `Positions`, `WorkCalendars`, `CustomerSites` (file `Controllers/ResourceManagementController.cs`).
- Thêm các ViewModel dashboard mới: `ResourceManagementDashboardViewModel`, `HumanResourceOverviewViewModel`, `EquipmentResourceOverviewViewModel`, `InventoryResourceOverviewViewModel`, `InfrastructureResourceOverviewViewModel` (mở rộng `ViewModels/ViewModels.cs`).
- Thêm view `Views/ResourceManagement/Index.cshtml` hiển thị 4 block thông tin theo nhóm nghiệp vụ (Nhân lực, Thiết bị, Vật tư/Kho, Cơ sở hạ tầng).
- Bổ sung entry menu trong sidebar để truy cập luồng mới (`Views/Shared/_Layout.cshtml`) với nhãn "Quản lý tài nguyên".

### Testing
- Attempted to run `dotnet build` in the environment but it failed with `/bin/bash: dotnet: command not found`, so no build/test completed.
- Project files were lint-inspected via file searches and view/controller scaffolding was validated by reading the updated files; no automated test suite executed due to missing `.NET` runtime/tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c343b8f3c8333b1288792a78d044c)